### PR TITLE
Adding block cache so that it can support full page caching of concrete5

### DIFF
--- a/blocks/mauticcontent/controller.php
+++ b/blocks/mauticcontent/controller.php
@@ -14,6 +14,10 @@ class Controller extends BlockController
     protected $btTable = 'mauticDynamicContents';
     protected $btInterfaceWidth = "600";
     protected $btInterfaceHeight = "400";
+    protected $btCacheBlockRecord = true;
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
     
     public $mautic_base_url = "";
     public $mautic_slot_name = "";

--- a/blocks/mauticform/controller.php
+++ b/blocks/mauticform/controller.php
@@ -14,6 +14,10 @@ class Controller extends BlockController
     protected $btTable = 'mauticForms';
     protected $btInterfaceWidth = "600";
     protected $btInterfaceHeight = "400";
+    protected $btCacheBlockRecord = true;
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
     
     public $mautic_base_url = "";
     public $mautic_form_id = "";

--- a/blocks/mautictracker/controller.php
+++ b/blocks/mautictracker/controller.php
@@ -18,7 +18,7 @@ class Controller extends BlockController
     protected $btCacheBlockRecord = true;
     protected $btCacheBlockOutput = true;
     protected $btCacheBlockOutputOnPost = true;
-    protected $btCacheBlockOutputForRegisteredUsers = false;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
 
     public $mautic_base_url = "";
 

--- a/blocks/mauticvideo/controller.php
+++ b/blocks/mauticvideo/controller.php
@@ -14,6 +14,10 @@ class Controller extends BlockController
     protected $btTable = 'mauticVideos';
     protected $btInterfaceWidth = "600";
     protected $btInterfaceHeight = "400";
+    protected $btCacheBlockRecord = true;
+    protected $btCacheBlockOutput = true;
+    protected $btCacheBlockOutputOnPost = true;
+    protected $btCacheBlockOutputForRegisteredUsers = true;
 
     public $mautic_base_url = "";
     public $mautic_gate_time = 15;


### PR DESCRIPTION
In concrete5, they have cache system.
But all blocks doesn't have the setting to support cache.

## Adding cache option

I don't find any reason why Form, Content and Video should allow concrete5 to cache its content.
Since the dynamic contents are loaded via JS, so cocnrete5 side could be cached.
Therefore, I add the option to cache.

## Tracker cache setting to be true for registered user

Changed the cache setting to registered user.

I can see the cases where concrete5 accept public registration such as community site.
"register usess" also include those public users.

So I suggest to change to cache the registered user as well.

Thanks.