### PR TITLE
Fix class not found error

### DIFF
--- a/controllers/single_page/dashboard/system/mautic/settings.php
+++ b/controllers/single_page/dashboard/system/mautic/settings.php
@@ -1,8 +1,8 @@
 <?php
 namespace Concrete\Package\Mautic\Controller\SinglePage\Dashboard\System\Mautic;
 
+use Concrete\Core\Package\Package;
 use \Concrete\Core\Page\Controller\DashboardPageController;
-use Concrete\Core\Support\Facade\Package;
 
 class Settings extends DashboardPageController
 {


### PR DESCRIPTION
This imported class name does not exist in concrete5 5.7.x.
Also, this usage is not correct in concrete5 8.x.
Let's use the correct class instead ;-)