### PR TITLE
Support mt() Events

### DIFF
--- a/src/Concrete/Asset/Tracker.php
+++ b/src/Concrete/Asset/Tracker.php
@@ -16,6 +16,14 @@ class Tracker extends Asset
      * @var array
      */
     private $parameters = [];
+    /**
+     * @var string
+     */
+    private $onload = '';
+    /**
+     * @var string
+     */
+    private $onerror = '';
 
     /**
      * @return string
@@ -67,6 +75,38 @@ class Tracker extends Asset
     /**
      * @return string
      */
+    public function getOnLoadFunction()
+    {
+        return $this->onload;
+    }
+
+    /**
+     * @param string $function
+     */
+    public function setOnLoadFunction($function)
+    {
+        $this->onload = $function;
+    }
+
+    /**
+     * @return string
+     */
+    public function getOnErrorFunction()
+    {
+        return $this->onerror;
+    }
+
+    /**
+     * @param string $function
+     */
+    public function setOnErrorFunction($function)
+    {
+        $this->onerror = $function;
+    }
+
+    /**
+     * @return string
+     */
     public function getAssetDefaultPosition()
     {
         return Asset::ASSET_POSITION_FOOTER;
@@ -87,13 +127,24 @@ class Tracker extends Asset
     {
         if ($this->url) {
             $params = json_encode($this->parameters);
+            $events = '{';
+            if ($this->onload) {
+                $events .= sprintf('onload: function() {%s}', $this->onload);
+                if ($this->onerror) {
+                    $events .= ',';
+                }
+            }
+            if ($this->onerror) {
+                $events .= sprintf('onerror: function() {%s}', $this->onerror);
+            }
+            $events .= '}';
             $js = <<<JS
 <script>
     (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
         w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
         m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
     })(window,document,'script','{$this->url}/mtc.js','mt');
-    mt('send', 'pageview', $params);
+    mt('send', 'pageview', $params, $events);
 </script>
 JS;
             return $js;


### PR DESCRIPTION
Let's make it enable to add onload & onerror events from outside of the package.

Example usage:

```
$app = \Concrete\Core\Support\Facade\Facade::getFacadeApplication();
$director = $app->make('director');
$director->addListener('on_before_dispatch', function () use ($app) {
    $mautic = $app->make(\Concrete\Package\Mautic\Asset\Tracker::class);
    $mautic->setParam('foo', 'bar');
    $mautic->setOnLoadFunction("alert('Tracking request is loaded');");
    $mautic->setOnErrorFunction("alert('Tracking request is error');");
});
```

Output:

```
<script>
    (function(w,d,t,u,n,a,m){w['MauticTrackingObject']=n;
        w[n]=w[n]||function(){(w[n].q=w[n].q||[]).push(arguments)},a=d.createElement(t),
        m=d.getElementsByTagName(t)[0];a.async=1;a.src=u;m.parentNode.insertBefore(a,m)
    })(window,document,'script','https://mautic.test/mtc.js','mt');
    mt('send', 'pageview', {"foo":"bar"}, {onload: function() {alert('Tracking request is loaded');},onerror: function() {alert('Tracking request is error');}});
</script>
```